### PR TITLE
edits to custom transformers lab

### DIFF
--- a/travis/5-custom-transformers.md
+++ b/travis/5-custom-transformers.md
@@ -197,7 +197,7 @@ With these questions answered, you can add the following code to the `transforme
 runner "linux", ["new-runner", "self-hosted"]
 ```
 
-In this example, the first parameter to the `runner` method is the Azure DevOps label and the second is the Actions runner labels.
+In this example, the first parameter to the `runner` method is the Travis CI label and the second is the GitHub Actions runner labels.
 
 Now you can perform another `dry-run` command with the `--custom-transformers` CLI option.  When you open the converted workflow, the `runs-on` statement will use the customized runner labels:
 


### PR DESCRIPTION
Note: line 200 might include an error.

In this example, the first parameter to the `runner` method is the Azure DevOps label and the second is the Actions runner labels.

should Azure DevOps be Travis CI?