### PR TITLE
Only 'commit' code files

### DIFF
--- a/azure_devops/bootstrap/setup
+++ b/azure_devops/bootstrap/setup
@@ -92,7 +92,7 @@ def create_repository(options)
     }],
     commits: [{
       comment: "Initial commit.",
-      changes: Dir[File.join(tmp_dir, "**/*")].reject {|f| File.directory?(f) }.map do |entry|
+      changes: Dir[File.join(tmp_dir, "**/*.{cs,csproj,sln}")].reject {|f| File.directory?(f) }.map do |entry|
         {
           changeType: "add",
           item: {


### PR DESCRIPTION
When creating the example repo in azure devops, non-code files sometimes start with non-standard characters (e.g. a BOM character).

As a result we are unable to successfully JSON encode the body to create the repo, resulting in the setup script erroring out.

## Example

```
Extracting assets...
Creating repository test-project-3...
./azure_devops/bootstrap/setup:31:in `to_json': source sequence is illegal/malformed utf-8 (JSON::GeneratorError)
        from ./azure_devops/bootstrap/setup:31:in `block in post_request'
        from /usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/net/http.rb:985:in `start'
        from /usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/net/http.rb:628:in `start'
        from ./azure_devops/bootstrap/setup:28:in `post_request'
        from ./azure_devops/bootstrap/setup:113:in `create_repository'
        from ./azure_devops/bootstrap/setup:193:in `<main>'
```

![Screenshot 2022-12-08 at 17 23 30](https://user-images.githubusercontent.com/13201458/206592965-27d37ce1-b9c5-41d3-bed8-fa4f1298d1a5.png)

