### PR TITLE
Pin GitLab Version and Set Minimum Host Requirements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,11 @@
     "DOCKER_ARGS": "--network=host",
     "INSTALLATION_TYPE": "labs"
   },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
+  },
   "customizations": {
     "vscode": {
       "settings": {

--- a/gitlab/bootstrap/setup.sh
+++ b/gitlab/bootstrap/setup.sh
@@ -27,7 +27,7 @@ else
   --volume /srv/gitlab/logs:/var/log/gitlab \
   --volume /srv/gitlab/data:/var/opt/gitlab \
   --shm-size 256m \
-  gitlab/gitlab-ee:latest
+  gitlab/gitlab-ee:15.5.6-ee.0
 
   # updates file permissions to avoid git and server errors
   docker exec -it gitlab update-permissions &> /dev/null


### PR DESCRIPTION
## What is Changing
- Sets Group used in GitLab data to `actions-importer`
- Pins version of GitLab to 15.6.2
- Sets host requirement in devcontainer config to 4 cores to mitigate very long start up times with 2 cores

## How was this Tested
👀 

Closes #github/valet#4993