### PR TITLE
Commit Yaml pipeline files during Azure bootstrap

### DIFF
--- a/azure_devops/bootstrap/setup
+++ b/azure_devops/bootstrap/setup
@@ -92,7 +92,7 @@ def create_repository(options)
     }],
     commits: [{
       comment: "Initial commit.",
-      changes: Dir[File.join(tmp_dir, "**/*.{cs,csproj,sln}")].reject {|f| File.directory?(f) }.map do |entry|
+      changes: Dir[File.join(tmp_dir, "**/*.{cs,csproj,sln,yml}")].reject {|f| File.directory?(f) }.map do |entry|
         {
           changeType: "add",
           item: {


### PR DESCRIPTION
The pipeline definitions (defined in `azure_devops/bootstrap/azure_devops.tgz`) were not being committed when bootstrapping the Azure repo. This causes 404s when trying to extract the pipeline in commands like `audit`. Including the pipeline definitions in the commit resolves this issue.

Heres an example of the error I ran into:
```
[2023-01-04 16:58:28] Logs: 'tmp/audit/log/valet-20230104-165828.log'
[2023-01-04 16:58:28] Auditing 'https://dev.azure.com/stves/importer-labs-demo/_build'
[2023-01-04 16:58:29] There was an error extracting the Azure DevOps pipeline (https://dev.azure.com/stves/importer-labs-demo/_build?definitionId=3)
                      Message: Resource not found
                      (GET 404) Not Found: https://dev.azure.com/stves/importer-labs-demo/_apis/git/repositories/importer-labs-demo/items?api-version=5.0-preview&path=%2Fpipelines%2Fyml%2Fpipeline2.yml&versionDescriptor.version=main
[2023-01-04 16:58:29] There was an error extracting the Azure DevOps pipeline (https://dev.azure.com/stves/importer-labs-demo/_build?definitionId=2)
[2023-01-04 16:58:29] There was an error extracting the Azure DevOps pipeline (https://dev.azure.com/stves/importer-labs-demo/_build?definitionId=1)
[2023-01-04 16:58:29] Output file(s):==========================================|
[2023-01-04 16:58:29]   tmp/audit/pipelines/importer-labs-demo/pipelines/pipeline2/error.txt
[2023-01-04 16:58:29]   tmp/audit/pipelines/importer-labs-demo/pipelines/pipeline2/config.json
[2023-01-04 16:58:29]   tmp/audit/pipelines/importer-labs-demo/pipelines/pipeline1/error.txt
[2023-01-04 16:58:29]   tmp/audit/pipelines/importer-labs-demo/pipelines/pipeline1/config.json
[2023-01-04 16:58:29]   tmp/audit/pipelines/importer-labs-demo/pipelines/custom-transformer-example/error.txt
[2023-01-04 16:58:29]   tmp/audit/pipelines/importer-labs-demo/pipelines/custom-transformer-example/config.json
[2023-01-04 16:58:29]   tmp/audit/workflow_usage.csv
[2023-01-04 16:58:29]   tmp/audit/audit_summary.md
```