### PR TITLE
CircleCI: Add Note About "Resource not found" warnings

### DIFF
--- a/circle_ci/2-audit.md
+++ b/circle_ci/2-audit.md
@@ -31,7 +31,7 @@ You will be performing an `audit` for the __actions-importer-labs__ CircleCI org
 
 3. The command will list all the files written to disk in green when the command succeeds.
 
-   _Note:  It is expected to see "Resource not found" warnings in the output.  These warnings are present because you are not a member of the CircleCI organization actions-importer-labs._
+   **Note**:  It is expected that you will see "Resource not found" warnings in the output. These warnings are present because you are not a member of the CircleCI organization actions-importer-labs.
    
 ## Inspect the output files
 

--- a/circle_ci/2-audit.md
+++ b/circle_ci/2-audit.md
@@ -31,6 +31,8 @@ You will be performing an `audit` for the __actions-importer-labs__ CircleCI org
 
 3. The command will list all the files written to disk in green when the command succeeds.
 
+   _Note:  It is expected to see "Resource not found" warnings in the output.  These warnings are present because you are not a member of the CircleCI organization actions-importer-labs._
+   
 ## Inspect the output files
 
 1. Find the `audit_summary.md` file in the file explorer.

--- a/circle_ci/4-dry-run.md
+++ b/circle_ci/4-dry-run.md
@@ -36,6 +36,8 @@ You will be performing a dry run migration against a CircleCI project. Answer th
     [2022-09-19 19:46:05]  tmp/dry-run/actions-importer-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
     ```
 
+    _Note:  It is expected to see "Resource not found" warnings in the output.  These warnings are present because you are not a member of the CircleCI organization actions-importer-labs._
+
 4. View the converted workflow:
     - Find `tmp/dry-run/actions-importer-labs/circleci-demo-ruby-rails/.github/workflows` in the file explorer pane in your codespace.
     - Click `build_and_test.yml` to open.

--- a/circle_ci/4-dry-run.md
+++ b/circle_ci/4-dry-run.md
@@ -36,7 +36,7 @@ You will be performing a dry run migration against a CircleCI project. Answer th
     [2022-09-19 19:46:05]  tmp/dry-run/actions-importer-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
     ```
 
-    _Note:  It is expected to see "Resource not found" warnings in the output.  These warnings are present because you are not a member of the CircleCI organization actions-importer-labs._
+    **Note**:  It is expected that you will see "Resource not found" warnings in the output. These warnings are present because you are not a member of the CircleCI organization actions-importer-labs.
 
 4. View the converted workflow:
     - Find `tmp/dry-run/actions-importer-labs/circleci-demo-ruby-rails/.github/workflows` in the file explorer pane in your codespace.

--- a/circle_ci/6-migrate.md
+++ b/circle_ci/6-migrate.md
@@ -35,6 +35,8 @@ Answer the following questions before running a `migrate` command:
     [2022-08-20 22:08:20] Pull request: 'https://github.com/:owner/:repo/pull/1'
     ```
 
+    _Note:  It is expected to see "Resource not found" warnings in the output.  These warnings are present because you are not a member of the CircleCI organization actions-importer-labs._
+
 3. Open the generated pull request in a new browser tab.
 
 ### Inspect the pull request

--- a/circle_ci/6-migrate.md
+++ b/circle_ci/6-migrate.md
@@ -35,7 +35,7 @@ Answer the following questions before running a `migrate` command:
     [2022-08-20 22:08:20] Pull request: 'https://github.com/:owner/:repo/pull/1'
     ```
 
-    _Note:  It is expected to see "Resource not found" warnings in the output.  These warnings are present because you are not a member of the CircleCI organization actions-importer-labs._
+    **Note**:  It is expected that you will see "Resource not found" warnings in the output. These warnings are present because you are not a member of the CircleCI organization actions-importer-labs.
 
 3. Open the generated pull request in a new browser tab.
 


### PR DESCRIPTION
## What is Changing?
This adds a note to the CircleCI audit, dry-run, and migrate labs explaining that the user is expected to see "Resource not found" warnings in the example command output.  This happens because the context request is failing because the user is not part of CircleCI organization.  We are not using information in the organization context so the fact it fails does not matter

## How was it tested?
👀  

Closes github/valet#4956