### PR TITLE
CircleCI: adding note about puts

### DIFF
--- a/circle_ci/5-custom-transformers.md
+++ b/circle_ci/5-custom-transformers.md
@@ -125,7 +125,7 @@ transform "codecov_codecov_upload" do |item|
 end
 ```
 
-In this case, `puts` will only print `{}` to the console since there are no properties of the CircleCI step. In the source configuration, it simply appears as:
+In this example, `puts` will output an empty hash (i.e. `{}`) to the console since there are no properties configured for the CircleCI step. The step from the CircleCI pipeline is:
 
 ```yml
 - codecov/upload

--- a/circle_ci/5-custom-transformers.md
+++ b/circle_ci/5-custom-transformers.md
@@ -125,6 +125,12 @@ transform "codecov_codecov_upload" do |item|
 end
 ```
 
+In this case, `puts` will only print `{}` to the console since there are no properties of the CircleCI step. In the source configuration, it simply appears as:
+
+```yml
+- codecov/upload
+```
+
 ## Custom transformers for environment variables
 
 You can use custom transformers to edit the values of environment variables in converted workflows. In this example, you will update the `COVERAGE_DIR` environment variable to be `$RUNNER_TEMP/cov` instead of `./tmp/cov`.


### PR DESCRIPTION
I was initially confused why in the labs the `puts` wasn't showing much, but @kenmuse explained it's because the original yml has no properties :D 

Clarifying this point in the lab that you should expect to see `{}`

![image](https://user-images.githubusercontent.com/19912012/219745836-0027b5f2-0db1-4b4d-9388-cfaffd06e3b2.png)
