### PR TITLE
Update jenkins docker image version

### DIFF
--- a/jenkins/bootstrap/Dockerfile
+++ b/jenkins/bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.332.3-lts
+FROM jenkins/jenkins:2.332.4
 
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 ENV CASC_JENKINS_CONFIG /var/jenkins_home/casc.yaml


### PR DESCRIPTION
Jenkins version 2.332.3 was causing some issues. Various plugins were not installing correctly because they were dependent on version 2.332.4.

Another option to resolve this issue would be to not use `:latest` for our plugin versions, but based on what I investigated, we'd have to go back quite a few plugin versions to get a version that doesn't require 2.332.4. Also it's generally good for us to keep Jenkins up to date