### PR TITLE
Remove `DOCKER_ARGS`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "name": "Codespace to perform GitHub Actions Importer Labs",
   "remoteEnv": {
-    "DOCKER_ARGS": "--network=host",
     "INSTALLATION_TYPE": "labs"
   },
   "hostRequirements": {


### PR DESCRIPTION
## What is Changing
Removes `DOCKER_ARGS` because that will be adding in the gh extension in [PR 111](https://github.com/github/gh-actions-importer/pull/111)

🚨 This should only be merge once the release of `gh-actions-importer` is ready 🚨 

## How was it tested?
👀 