### PR TITLE
Add explicit credentials plugin version

### DIFF
--- a/jenkins/bootstrap/plugins.txt
+++ b/jenkins/bootstrap/plugins.txt
@@ -4,6 +4,7 @@ antisamy-markup-formatter:159.v25b_c67cd35fb_
 build-timeout:1.24
 cloudbees-folder:6.740.ve4f4ffa_dea_54
 configuration-as-code:1569.vb_72405b_80249
+credentials:1087.1089.v2f1b_9a_b_040e4
 credentials-binding:523.vd859a_4b_122e6
 email-ext:2.92
 git:4.12.1


### PR DESCRIPTION
Something in Jenkins released recently which caused the base docker container to pull in a later version of the `credentials` plugin. The later version of the `credentials` plugin requires a more recent version of jenkins. This change forces the version of the `credentials` plugin to a working version for Jenkins 3.332.4

Prior to this change, the later version of the credentials plugin failing to install caused many other plugins that depend on that plugin to fail to install as well. This resulted in pipeline transformation failures because required API endpoints from the failed plugin installs were missing.