### PR TITLE
Remove reference to old s3 bucket 

### DIFF
--- a/bamboo/bootstrap/source_files/bonnie/source.yml
+++ b/bamboo/bootstrap/source_files/bonnie/source.yml
@@ -108,7 +108,7 @@ Deploy:
         credentialsId: '10092545'
         region: US_WEST_1
         applicationName: AppECS-user_cluster-alt_service
-        s3Bucket: elasticbeanstalk-us-west-1-778232459879
+        s3Bucket: elasticbeanstalk-us-west-1-12345
         workingSubDirectory: this_is_a_subdir
       conditions:
       - variable:


### PR DESCRIPTION
Removing refrence to old s3 bucket we created in order to create this demo pipeline. 

The s3 bucket no longer exists. 

Related to: https://github.com/github/valet/issues/7306