### PR TITLE
Update 3-forecast.md

### DIFF
--- a/gitlab/3-forecast.md
+++ b/gitlab/3-forecast.md
@@ -104,7 +104,7 @@ You can use the `--source-file-path` CLI option to combine data from multiple re
 Run the following command from within the codespace terminal:
 
 ```bash
-gh actions-importer forecast --source-file-path tmp/**/jobs/*.json --output-dir tmp/forecast-combined
+gh actions-importer forecast --source-file-path tmp/**/jobs/*.json --output-dir tmp/forecast-combined --start-date 2022-08-02
 ```
 
 You can now inspect the output of the command to see a forecast report using all of the files matching the `tmp/**/jobs/*.json` pattern.


### PR DESCRIPTION
Add needed `--start-date` flag to "Forecasting multiple providers" command.

Without the flag, no report is generated, and the log file includes a warning that no jobs were transformed:

```
# Logfile created on 2024-10-09 22:46:39 +0000 by logger.rb/v1.6.0
I, [2024-10-09T22:46:39.075648 #1]  INFO -- : Using GitHub Features: Defaults
I, [2024-10-09T22:46:39.075696 #1]  INFO -- : Forecasting '/data/tmp/forecast/jobs/10-09-2024-22-44_jobs_0.json'
W, [2024-10-09T22:46:39.084369 #1]  WARN -- : No jobs transformed
```